### PR TITLE
Library Configurations

### DIFF
--- a/paper-bin/src/main.rs
+++ b/paper-bin/src/main.rs
@@ -15,9 +15,9 @@ async fn main() {
         username: None,
         password: None,
         api_configuration: APIConfiguration {
-            api: API::HamburgPublic,
-            base_url: "https://www.buecherhallen.de".to_string(),
-            catalog_url: "https://www.buecherhallen.de".to_string(),
+            api: API::Opc4v2_13Vzg6,
+            base_url: "https://lbssbb.gbv.de".to_string(),
+            catalog_url: "https://lbssbb.gbv.de".to_string(),
         },
     };
 

--- a/paper-bin/src/main.rs
+++ b/paper-bin/src/main.rs
@@ -1,6 +1,6 @@
 extern crate paper;
 
-use paper::{configuration::Configuration, model::APIConfiguration, model::API};
+use paper::{configuration::Configuration, model::API};
 
 #[macro_use]
 extern crate clap;
@@ -14,10 +14,10 @@ async fn main() {
     let mut configuration = Configuration {
         username: None,
         password: None,
-        api_configuration: APIConfiguration {
-            api: API::Opc4v2_13Vzg6,
+        api_configuration: API::Opc4v2_13Vzg6 {
             base_url: "https://lbssbb.gbv.de".to_string(),
             catalog_url: "https://lbssbb.gbv.de".to_string(),
+            user_query_key: "1000".to_string(),
         },
     };
 

--- a/paper/src/authenticators/opac_authenticator.rs
+++ b/paper/src/authenticators/opac_authenticator.rs
@@ -10,11 +10,16 @@ impl OpacAuthenticator {
     pub(crate) async fn authenticate(&self, client: &Client) -> Result<bool, PaperError> {
         let username = self.configuration.username.clone().unwrap();
         let password = self.configuration.password.clone().unwrap();
-        let login_url = self.configuration.login_url();
+        let login_url = self.configuration.api_configuration.login_url().unwrap();
+        let user_query_key = self
+            .configuration
+            .api_configuration
+            .user_query_key()
+            .unwrap();
         let html_string = client
-            .post(login_url.clone())
+            .post(login_url)
             .query(&[
-                ("USR", "1000"),
+                ("USR", user_query_key.as_str()),
                 ("BES", "1"),
                 ("LAN", "DU"),
                 ("username", username.as_str()),

--- a/paper/src/authenticators/opac_authenticator.rs
+++ b/paper/src/authenticators/opac_authenticator.rs
@@ -8,14 +8,13 @@ pub(crate) struct OpacAuthenticator {
 
 impl OpacAuthenticator {
     pub(crate) async fn authenticate(&self, client: &Client) -> Result<bool, PaperError> {
-        println!("`OpacAuthenticator::authenticate`");
         let username = self.configuration.username.clone().unwrap();
         let password = self.configuration.password.clone().unwrap();
         let login_url = self.configuration.login_url();
         let html_string = client
-            .post(login_url)
+            .post(login_url.clone())
             .query(&[
-                ("USR", "1022"),
+                ("USR", "1000"),
                 ("BES", "1"),
                 ("LAN", "DU"),
                 ("username", username.as_str()),
@@ -25,6 +24,7 @@ impl OpacAuthenticator {
             .await?
             .text()
             .await?;
+
         let scraper = Opc4v2_13Vzg6AccountScraper {
             configuration: self.configuration.clone(),
         };

--- a/paper/src/authenticators/public_hamburg_authenticator.rs
+++ b/paper/src/authenticators/public_hamburg_authenticator.rs
@@ -1,9 +1,9 @@
 use super::{LoginResult, RawLoansPage};
+use crate::configuration::Configuration;
 use crate::error::PaperError;
 use crate::model::Loans;
 use crate::scrapers::public_hamburg::LoansScraper;
 use crate::token_scraper::TokenScraper;
-use crate::{configuration::Configuration};
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     Client,
@@ -69,7 +69,7 @@ impl PublicHamburgAuthenticator {
         client: &Client,
     ) -> Result<Loans, PaperError> {
         let token_scraper = TokenScraper {
-            api: self.configuration.api_configuration.api.clone(),
+            api: self.configuration.api_configuration.clone(),
         };
 
         let token = token_scraper.get_request_token(&client).await?;
@@ -90,7 +90,7 @@ impl PublicHamburgAuthenticator {
         client: &Client,
     ) -> Result<String, PaperError> {
         let token_scraper = TokenScraper {
-            api: self.configuration.api_configuration.api.clone(),
+            api: self.configuration.api_configuration.clone(),
         };
 
         let request_token = token_scraper.get_request_token(&client).await?;

--- a/paper/src/authenticators/scrape_authenticator.rs
+++ b/paper/src/authenticators/scrape_authenticator.rs
@@ -3,6 +3,10 @@ use crate::configuration::Configuration;
 use crate::error::PaperError;
 use crate::model::ValidationStatus;
 
+use reqwest::cookie::Jar;
+use reqwest::ClientBuilder;
+use std::sync::Arc;
+
 #[derive(uniffi::Object)]
 pub struct Authenticator {
     pub(crate) configuration: Configuration,

--- a/paper/src/authenticators/scrape_authenticator.rs
+++ b/paper/src/authenticators/scrape_authenticator.rs
@@ -3,10 +3,6 @@ use crate::configuration::Configuration;
 use crate::error::PaperError;
 use crate::model::ValidationStatus;
 
-use reqwest::cookie::Jar;
-use reqwest::ClientBuilder;
-use std::sync::Arc;
-
 #[derive(uniffi::Object)]
 pub struct Authenticator {
     pub(crate) configuration: Configuration,
@@ -20,7 +16,7 @@ impl Authenticator {
     }
 
     async fn verify_credentials(&self) -> Result<ValidationStatus, PaperError> {
-        match self.configuration.api_configuration.api {
+        match self.configuration.api_configuration {
             crate::model::API::HamburgPublic => {
                 let authenticator = PublicHamburgAuthenticator {
                     configuration: self.configuration.clone(),
@@ -34,7 +30,7 @@ impl Authenticator {
                     },
                 };
             }
-            crate::model::API::Opc4v2_13Vzg6 => {
+            crate::model::API::Opc4v2_13Vzg6 { .. } => {
                 let opac_authenticator = OpacAuthenticator {
                     configuration: self.configuration.clone(),
                 };

--- a/paper/src/configuration.rs
+++ b/paper/src/configuration.rs
@@ -1,28 +1,10 @@
-use crate::model::APIConfiguration;
+use crate::model::API;
 
 #[derive(Debug, uniffi::Record, Clone)]
 pub struct Configuration {
     pub username: Option<String>,
     pub password: Option<String>,
-    pub api_configuration: APIConfiguration,
-}
-
-impl Configuration {
-    pub fn login_url(&self) -> String {
-        format!("{}/LBS_WEB/login", self.api_configuration.base_url)
-    }
-
-    pub fn base_url(&self) -> String {
-        self.api_configuration.base_url.clone()
-    }
-
-    pub fn session_url(&self) -> String {
-        //https://kataloge.hh.gbv.de/LBS_WEB/borrower/loans.htm
-        format!(
-            "{}/LBS_WEB/borrower/loans.htm",
-            self.api_configuration.base_url
-        )
-    }
+    pub api_configuration: API,
 }
 
 #[cfg(test)]
@@ -33,10 +15,10 @@ mod tests {
 
     #[test]
     fn test_login_url() {
-        let api_config = APIConfiguration {
-            api: API::Opc4v2_13Vzg6,
+        let api_config = API::Opc4v2_13Vzg6 {
             base_url: String::from("https://example.com"),
             catalog_url: String::from("https://example.com"),
+            user_query_key: String::from("1022"),
         };
         let config = Configuration {
             username: Some(String::from("user")),
@@ -44,7 +26,7 @@ mod tests {
             api_configuration: api_config,
         };
 
-        let expected_url = "https://example.com/LBS_WEB/login";
-        assert_eq!(config.login_url(), expected_url);
+        assert_eq!(config.username, Some(String::from("user")));
+        assert_eq!(config.password, Some(String::from("pass")));
     }
 }

--- a/paper/src/lib.rs
+++ b/paper/src/lib.rs
@@ -161,7 +161,7 @@ impl Paper {
 #[cfg(test)]
 mod tests {
 
-    use model::{APIConfiguration, API};
+    use model::API;
 
     use super::*;
     #[test]
@@ -169,11 +169,7 @@ mod tests {
         let config = Configuration {
             username: Some("abc".to_string()),
             password: Some("123".to_string()),
-            api_configuration: APIConfiguration {
-                api: API::HamburgPublic,
-                base_url: "https://www.buecherhallen.de".to_string(),
-                catalog_url: "https://catalog.buecherhallen.de".to_string(),
-            },
+            api_configuration: API::HamburgPublic,
         };
         let paper = Paper::with_config(config);
         assert_eq!(paper.configuration.username, Some("abc".to_string()));

--- a/paper/src/lib.rs
+++ b/paper/src/lib.rs
@@ -12,7 +12,7 @@ use crate::configuration::Configuration;
 use crate::model::{Account, SearchResultList, SearchResultListItem};
 
 extern crate indicatif;
-use crate::scrapers::public_hamburg::HamburgPublicSearchScraper;
+use crate::scrapers::SearchScraper;
 use console::{style, Term};
 use dialoguer::{theme::ColorfulTheme, Input, Select};
 use indicatif::ProgressBar;
@@ -102,7 +102,7 @@ impl Paper {
             .interact_text()
             .unwrap();
 
-        let search = HamburgPublicSearchScraper {};
+        let search = SearchScraper::new(self.configuration.api_configuration.clone());
 
         match search.search(&input, None).await {
             Ok(result) => Self::print_search_result(result),

--- a/paper/src/lib.rs
+++ b/paper/src/lib.rs
@@ -43,7 +43,7 @@ impl Paper {
             .build()
             .unwrap();
         let account = scraper
-            .public_hamburg_fetch_on_current_runtime(&client)
+            .opc4v2_13vzg6_fetch_on_current_runtime(&client)
             .await
             .unwrap();
 

--- a/paper/src/model/api.rs
+++ b/paper/src/model/api.rs
@@ -1,4 +1,4 @@
-#[derive(uniffi::Enum, Clone, Debug)]
+#[derive(uniffi::Enum, Clone, Debug, PartialEq)]
 pub enum API {
     HamburgPublic,
     Opc4v2_13Vzg6 {

--- a/paper/src/model/api.rs
+++ b/paper/src/model/api.rs
@@ -1,5 +1,86 @@
-#[derive(uniffi::Enum, Debug, Clone)]
+#[derive(uniffi::Enum, Clone, Debug)]
 pub enum API {
     HamburgPublic,
-    Opc4v2_13Vzg6,
+    Opc4v2_13Vzg6 {
+        base_url: String,
+        catalog_url: String,
+        user_query_key: String,
+    },
+}
+
+impl API {
+    pub fn base_url(&self) -> String {
+        match self {
+            API::HamburgPublic => "https://www.buecherhallen.de".to_string(),
+            API::Opc4v2_13Vzg6 { base_url, .. } => base_url.clone(),
+        }
+    }
+
+    pub fn catalog_url(&self) -> String {
+        match self {
+            API::HamburgPublic => "https://buecherhallen.de".to_string(),
+            API::Opc4v2_13Vzg6 { catalog_url, .. } => catalog_url.clone(),
+        }
+    }
+
+    pub fn login_url(&self) -> Option<String> {
+        match self {
+            API::HamburgPublic => None,
+            API::Opc4v2_13Vzg6 { .. } => Some(format!("{}/LBS_WEB/login", self.base_url().clone())),
+        }
+    }
+
+    pub fn session_url(&self) -> Option<String> {
+        //https://kataloge.hh.gbv.de/LBS_WEB/borrower/loans.htm
+        match self {
+            API::HamburgPublic => None,
+            API::Opc4v2_13Vzg6 { .. } => Some(format!(
+                "{}/LBS_WEB/borrower/loans.htm",
+                self.base_url().clone()
+            )),
+        }
+    }
+
+    pub fn user_query_key(&self) -> Option<String> {
+        match self {
+            API::HamburgPublic => None,
+            API::Opc4v2_13Vzg6 { user_query_key, .. } => Some(user_query_key.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::API;
+
+    #[test]
+    fn test_login_url() {
+        let api_config = API::Opc4v2_13Vzg6 {
+            base_url: String::from("https://example.com"),
+            catalog_url: String::from("https://example.com"),
+            user_query_key: String::from("1000"),
+        };
+
+        let expected_url = "https://example.com/LBS_WEB/login";
+        assert_eq!(api_config.login_url(), Some(expected_url.to_string()));
+    }
+
+    #[test]
+    fn test_user_query_key() {
+        let api_config = API::Opc4v2_13Vzg6 {
+            base_url: String::from("https://example.com"),
+            catalog_url: String::from("https://example.com"),
+            user_query_key: String::from("1000"),
+        };
+
+        let expected_key = "1000";
+        assert_eq!(api_config.user_query_key(), Some(expected_key.to_string()));
+    }
+
+    #[test]
+    fn test_user_query_key_none() {
+        let api_config = API::HamburgPublic;
+
+        assert_eq!(api_config.user_query_key(), None);
+    }
 }

--- a/paper/src/model/api_configuration.rs
+++ b/paper/src/model/api_configuration.rs
@@ -1,8 +1,0 @@
-use super::API;
-
-#[derive(uniffi::Record, Clone, Debug)]
-pub struct APIConfiguration {
-    pub api: API,
-    pub base_url: String,
-    pub catalog_url: String,
-}

--- a/paper/src/model/library.rs
+++ b/paper/src/model/library.rs
@@ -1,0 +1,9 @@
+use super::API;
+
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct Library {
+    pub identifier: String,
+    pub name: String,
+    pub subtitle: String,
+    pub api: API,
+}

--- a/paper/src/model/library.rs
+++ b/paper/src/model/library.rs
@@ -6,5 +6,6 @@ pub struct Library {
     pub name: String,
     pub subtitle: String,
     pub api: API,
-    pub enabled: bool,
+    pub enabled_for_search: bool,
+    pub enabled_for_login: bool,
 }

--- a/paper/src/model/library.rs
+++ b/paper/src/model/library.rs
@@ -6,4 +6,5 @@ pub struct Library {
     pub name: String,
     pub subtitle: String,
     pub api: API,
+    pub enabled: bool,
 }

--- a/paper/src/model/library_list.rs
+++ b/paper/src/model/library_list.rs
@@ -20,7 +20,8 @@ impl LibraryList {
                         catalog_url: "https://lbssbb.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "MAGDEBURG".to_string(),
@@ -31,7 +32,8 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-magdeburg.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "LUENEBURG".to_string(),
@@ -42,7 +44,8 @@ impl LibraryList {
                         catalog_url: "https://katalog.leuphana.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "BRAUNSCHWEIG".to_string(),
@@ -53,7 +56,8 @@ impl LibraryList {
                         catalog_url: "https://lbsbrs.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "WOLFENBUETTEL".to_string(),
@@ -65,7 +69,8 @@ impl LibraryList {
                         catalog_url: "https://lbsbrs.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "SHLB".to_string(),
@@ -76,7 +81,8 @@ impl LibraryList {
                         catalog_url: "https://katalog.ub.uni-kiel.de/DB=3".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "MUTHESIUS".to_string(),
@@ -87,7 +93,8 @@ impl LibraryList {
                         catalog_url: "https://katalog.ub.uni-kiel.de/DB=6".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "KIEL".to_string(),
@@ -98,7 +105,8 @@ impl LibraryList {
                         catalog_url: "https://katalog.ub.uni-kiel.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "ILFH".to_string(),
@@ -109,7 +117,8 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-ilmenau.gbv.de/DB=2".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "ILMENAU".to_string(),
@@ -120,7 +129,8 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-ilmenau.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HKSF".to_string(),
@@ -131,7 +141,8 @@ impl LibraryList {
                         catalog_url: "https://lbshan.gbv.de/DB=11".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HILDESHEIM".to_string(),
@@ -142,7 +153,8 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-hildesheim.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HFHH".to_string(),
@@ -153,7 +165,8 @@ impl LibraryList {
                         catalog_url: "https://opac.tib.eu/DB=4".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "LUH".to_string(),
@@ -164,7 +177,8 @@ impl LibraryList {
                         catalog_url: "https://opac.tib.eu/DB=12".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: false,
+                    enabled_for_search: false,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HELMUTSCHMIDT".to_string(),
@@ -175,7 +189,8 @@ impl LibraryList {
                         catalog_url: "https://lbshsu.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HARBURG".to_string(),
@@ -186,7 +201,8 @@ impl LibraryList {
                         catalog_url: "https://katalog.b.tuhh.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HAFENCITYUNI".to_string(),
@@ -197,7 +213,8 @@ impl LibraryList {
                         catalog_url: "https://katalog.b.tuhh.de/DB=22".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HANNOVER".to_string(),
@@ -208,7 +225,8 @@ impl LibraryList {
                         catalog_url: "https://lbshan.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HAMBURG".to_string(),
@@ -219,14 +237,16 @@ impl LibraryList {
                         catalog_url: "https://kataloge.hh.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HAMBURGPUBLIC".to_string(),
                     name: "Hamburg".to_string(),
                     subtitle: "Stiftung Hamburger Öffentliche Bücherhallen".to_string(),
                     api: API::HamburgPublic,
-                    enabled: false,
+                    enabled_for_search: false,
+                    enabled_for_login: false,
                 },
                 Library {
                     identifier: "ROSTOCK".to_string(),
@@ -237,7 +257,8 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-rostock.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "GREIFSWALD".to_string(),
@@ -248,7 +269,8 @@ impl LibraryList {
                         catalog_url: "https://lhgrw.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: false,
+                    enabled_for_search: false,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "GOETTINGEN".to_string(),
@@ -259,7 +281,8 @@ impl LibraryList {
                         catalog_url: "https://opac.sub.uni-goettingen.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "WISMAR".to_string(),
@@ -270,7 +293,8 @@ impl LibraryList {
                         catalog_url: "https://lbswis.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "ERFURT".to_string(),
@@ -281,7 +305,8 @@ impl LibraryList {
                         catalog_url: "https://opac.uni-erfurt.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "HAW".to_string(),
@@ -292,7 +317,8 @@ impl LibraryList {
                         catalog_url: "https://kataloge.hh.gbv.de/DB=2".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "ANHALT".to_string(),
@@ -303,7 +329,8 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-anhalt.gbv.de".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: true,
+                    enabled_for_search: true,
+                    enabled_for_login: true,
                 },
                 Library {
                     identifier: "COMMERZ_HH".to_string(),
@@ -314,7 +341,8 @@ impl LibraryList {
                         catalog_url: "https://lbsvz2.gbv.de/DB=67".to_string(),
                         user_query_key: "1000".to_string(),
                     },
-                    enabled: false,
+                    enabled_for_search: false,
+                    enabled_for_login: true,
                 },
             ],
         }

--- a/paper/src/model/library_list.rs
+++ b/paper/src/model/library_list.rs
@@ -1,0 +1,305 @@
+use super::{Library, API};
+
+#[derive(Debug, uniffi::Object)]
+pub struct LibraryList {
+    pub libraries: Vec<Library>,
+}
+
+#[uniffi::export]
+impl LibraryList {
+    #[uniffi::constructor]
+    pub fn new() -> LibraryList {
+        LibraryList {
+            libraries: vec![
+                Library {
+                    identifier: "BERLIN".to_string(),
+                    name: "Berlin".to_string(),
+                    subtitle: "Staatsbibliothek Preußischer Kulturbesitz".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbssbb.gbv.de".to_string(),
+                        catalog_url: "https://lbssbb.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "MAGDEBURG".to_string(),
+                    name: "Magdeburg".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbssbb.gbv.de".to_string(),
+                        catalog_url: "https://opac.lbs-magdeburg.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "LUENEBURG".to_string(),
+                    name: "Lüneburg".to_string(),
+                    subtitle: "Leuphana Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://katalog.leuphana.gbv.de".to_string(),
+                        catalog_url: "https://katalog.leuphana.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "BRAUNSCHWEIG".to_string(),
+                    name: "Braunschweig".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbsbrs.gbv.de".to_string(),
+                        catalog_url: "https://lbsbrs.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "WOLFENBUETTEL".to_string(),
+                    name: "Herzog August Bibliothek Wolfenbüttel".to_string(),
+                    subtitle: "Forschungs- und Studienstätte für europäische Kulturgeschichte"
+                        .to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbsbrs.gbv.de".to_string(),
+                        catalog_url: "https://lbsbrs.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "SHLB".to_string(),
+                    name: "Kiel".to_string(),
+                    subtitle: "Schleswig-Holsteinische Landesbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://katalog.ub.uni-kiel.de".to_string(),
+                        catalog_url: "https://katalog.ub.uni-kiel.de/DB=3".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "MUTHESIUS".to_string(),
+                    name: "Kiel".to_string(),
+                    subtitle: "Muthesius Kunsthochschule".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://katalog.ub.uni-kiel.de".to_string(),
+                        catalog_url: "https://katalog.ub.uni-kiel.de/DB=6".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "KIEL".to_string(),
+                    name: "Kiel".to_string(),
+                    subtitle: "Christian-Albrechts-Universität zu Kiel".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://katalog.ub.uni-kiel.de".to_string(),
+                        catalog_url: "https://katalog.ub.uni-kiel.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "ILFH".to_string(),
+                    name: "Schmalkalden".to_string(),
+                    subtitle: "Cellarius-Hochschulbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.lbs-ilmenau.gbv.de".to_string(),
+                        catalog_url: "https://opac.lbs-ilmenau.gbv.de/DB=2".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "ILMENAU".to_string(),
+                    name: "Ilmenau".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.lbs-ilmenau.gbv.de".to_string(),
+                        catalog_url: "https://opac.lbs-ilmenau.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HKSF".to_string(),
+                    name: "Hannover".to_string(),
+                    subtitle: "Kurt-Schwitters-Forum".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbshan.gbv.de".to_string(),
+                        catalog_url: "https://lbshan.gbv.de/DB=11".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HILDESHEIM".to_string(),
+                    name: "Hildesheim".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.lbs-hildesheim.gbv.de".to_string(),
+                        catalog_url: "https://opac.lbs-hildesheim.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HFHH".to_string(),
+                    name: "Hannover".to_string(),
+                    subtitle: "Bibliothek der Hochschule Hannover".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.tib.eu".to_string(),
+                        catalog_url: "https://opac.tib.eu/DB=4".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "LUH".to_string(),
+                    name: "Hannover".to_string(),
+                    subtitle: "Leibniz Universität Hannover".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.tib.eu".to_string(),
+                        catalog_url: "https://opac.tib.eu/DB=12".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HELMUTSCHMIDT".to_string(),
+                    name: "Helmut-Schmidt-Universität".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbshsu.gbv.de".to_string(),
+                        catalog_url: "https://lbshsu.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HARBURG".to_string(),
+                    name: "Hamburg-Harburg".to_string(),
+                    subtitle: "Universitätsbibliothek der TUHH".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://katalog.b.tuhh.de".to_string(),
+                        catalog_url: "https://katalog.b.tuhh.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HAFENCITYUNI".to_string(),
+                    name: "Hamburg".to_string(),
+                    subtitle: "HafenCity Universität".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://katalog.b.tuhh.de".to_string(),
+                        catalog_url: "https://katalog.b.tuhh.de/DB=22".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HANNOVER".to_string(),
+                    name: "Hannover".to_string(),
+                    subtitle: "Technische Informationsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbshan.gbv.de".to_string(),
+                        catalog_url: "https://lbshan.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HAMBURG".to_string(),
+                    name: "Hamburg".to_string(),
+                    subtitle: "Staats und Universitätsbibliothek Hamburg".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://kataloge.hh.gbv.de".to_string(),
+                        catalog_url: "https://kataloge.hh.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HAMBURGPUBLIC".to_string(),
+                    name: "Hamburg".to_string(),
+                    subtitle: "Stiftung Hamburger Öffentliche Bücherhallen".to_string(),
+                    api: API::HamburgPublic,
+                },
+                Library {
+                    identifier: "ROSTOCK".to_string(),
+                    name: "Rostock".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.lbs-rostock.gbv.de".to_string(),
+                        catalog_url: "https://opac.lbs-rostock.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "GREIFSWALD".to_string(),
+                    name: "Greifswald".to_string(),
+                    subtitle: "Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lhgrw.gbv.de".to_string(),
+                        catalog_url: "https://lhgrw.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "GOETTINGEN".to_string(),
+                    name: "Göttingen".to_string(),
+                    subtitle: "Staats und Universitätsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.sub.uni-goettingen.de".to_string(),
+                        catalog_url: "https://opac.sub.uni-goettingen.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "WISMAR".to_string(),
+                    name: "Wismar".to_string(),
+                    subtitle: "Hochschulbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbswis.gbv.de".to_string(),
+                        catalog_url: "https://lbswis.gbv.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "ERFURT".to_string(),
+                    name: "Erfurt/Gotha".to_string(),
+                    subtitle: "Universitäts- und Forschungsbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.uni-erfurt.de".to_string(),
+                        catalog_url: "https://opac.uni-erfurt.de/DB=1".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "HAW".to_string(),
+                    name: "Hamburg".to_string(),
+                    subtitle: "Hochschule für Angewandte Wissenschaften".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://kataloge.hh.gbv.de".to_string(),
+                        catalog_url: "https://kataloge.hh.gbv.de/DB=2".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "ANHALT".to_string(),
+                    name: "Anhalt".to_string(),
+                    subtitle: "Hochschule Anhalt".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://opac.lbs-anhalt.gbv.de".to_string(),
+                        catalog_url: "https://opac.lbs-anhalt.gbv.de".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+                Library {
+                    identifier: "COMMERZ_HH".to_string(),
+                    name: "Hamburg".to_string(),
+                    subtitle: "Commerzbibliothek".to_string(),
+                    api: API::Opc4v2_13Vzg6 {
+                        base_url: "https://lbsvz2.gbv.de".to_string(),
+                        catalog_url: "https://lbsvz2.gbv.de/DB=67".to_string(),
+                        user_query_key: "1000".to_string(),
+                    },
+                },
+            ],
+        }
+    }
+
+    pub fn library_for_identifier(&self, identifier: &str) -> Option<Library> {
+        self.libraries
+            .iter()
+            .find(|library| library.identifier == identifier)
+            .cloned()
+    }
+
+    pub fn libraries(&self) -> Vec<Library> {
+        self.libraries.clone()
+    }
+}

--- a/paper/src/model/library_list.rs
+++ b/paper/src/model/library_list.rs
@@ -20,6 +20,7 @@ impl LibraryList {
                         catalog_url: "https://lbssbb.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "MAGDEBURG".to_string(),
@@ -30,6 +31,7 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-magdeburg.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "LUENEBURG".to_string(),
@@ -40,6 +42,7 @@ impl LibraryList {
                         catalog_url: "https://katalog.leuphana.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "BRAUNSCHWEIG".to_string(),
@@ -50,6 +53,7 @@ impl LibraryList {
                         catalog_url: "https://lbsbrs.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "WOLFENBUETTEL".to_string(),
@@ -61,6 +65,7 @@ impl LibraryList {
                         catalog_url: "https://lbsbrs.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "SHLB".to_string(),
@@ -71,6 +76,7 @@ impl LibraryList {
                         catalog_url: "https://katalog.ub.uni-kiel.de/DB=3".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "MUTHESIUS".to_string(),
@@ -81,6 +87,7 @@ impl LibraryList {
                         catalog_url: "https://katalog.ub.uni-kiel.de/DB=6".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "KIEL".to_string(),
@@ -91,6 +98,7 @@ impl LibraryList {
                         catalog_url: "https://katalog.ub.uni-kiel.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "ILFH".to_string(),
@@ -101,6 +109,7 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-ilmenau.gbv.de/DB=2".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "ILMENAU".to_string(),
@@ -111,6 +120,7 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-ilmenau.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HKSF".to_string(),
@@ -121,6 +131,7 @@ impl LibraryList {
                         catalog_url: "https://lbshan.gbv.de/DB=11".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HILDESHEIM".to_string(),
@@ -131,6 +142,7 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-hildesheim.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HFHH".to_string(),
@@ -141,6 +153,7 @@ impl LibraryList {
                         catalog_url: "https://opac.tib.eu/DB=4".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "LUH".to_string(),
@@ -151,6 +164,7 @@ impl LibraryList {
                         catalog_url: "https://opac.tib.eu/DB=12".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: false,
                 },
                 Library {
                     identifier: "HELMUTSCHMIDT".to_string(),
@@ -161,6 +175,7 @@ impl LibraryList {
                         catalog_url: "https://lbshsu.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HARBURG".to_string(),
@@ -171,6 +186,7 @@ impl LibraryList {
                         catalog_url: "https://katalog.b.tuhh.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HAFENCITYUNI".to_string(),
@@ -181,6 +197,7 @@ impl LibraryList {
                         catalog_url: "https://katalog.b.tuhh.de/DB=22".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HANNOVER".to_string(),
@@ -191,6 +208,7 @@ impl LibraryList {
                         catalog_url: "https://lbshan.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HAMBURG".to_string(),
@@ -201,12 +219,14 @@ impl LibraryList {
                         catalog_url: "https://kataloge.hh.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HAMBURGPUBLIC".to_string(),
                     name: "Hamburg".to_string(),
                     subtitle: "Stiftung Hamburger Öffentliche Bücherhallen".to_string(),
                     api: API::HamburgPublic,
+                    enabled: false,
                 },
                 Library {
                     identifier: "ROSTOCK".to_string(),
@@ -217,6 +237,7 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-rostock.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "GREIFSWALD".to_string(),
@@ -227,6 +248,7 @@ impl LibraryList {
                         catalog_url: "https://lhgrw.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: false,
                 },
                 Library {
                     identifier: "GOETTINGEN".to_string(),
@@ -237,6 +259,7 @@ impl LibraryList {
                         catalog_url: "https://opac.sub.uni-goettingen.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "WISMAR".to_string(),
@@ -247,6 +270,7 @@ impl LibraryList {
                         catalog_url: "https://lbswis.gbv.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "ERFURT".to_string(),
@@ -257,6 +281,7 @@ impl LibraryList {
                         catalog_url: "https://opac.uni-erfurt.de/DB=1".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "HAW".to_string(),
@@ -267,6 +292,7 @@ impl LibraryList {
                         catalog_url: "https://kataloge.hh.gbv.de/DB=2".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "ANHALT".to_string(),
@@ -277,6 +303,7 @@ impl LibraryList {
                         catalog_url: "https://opac.lbs-anhalt.gbv.de".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: true,
                 },
                 Library {
                     identifier: "COMMERZ_HH".to_string(),
@@ -287,6 +314,7 @@ impl LibraryList {
                         catalog_url: "https://lbsvz2.gbv.de/DB=67".to_string(),
                         user_query_key: "1000".to_string(),
                     },
+                    enabled: false,
                 },
             ],
         }

--- a/paper/src/model/mod.rs
+++ b/paper/src/model/mod.rs
@@ -7,9 +7,6 @@ mod api;
 pub use self::validation_status::ValidationStatus;
 mod validation_status;
 
-pub use self::api_configuration::APIConfiguration;
-mod api_configuration;
-
 pub use self::notification::Notification;
 pub use self::notification::NotificationType;
 mod notification;

--- a/paper/src/model/mod.rs
+++ b/paper/src/model/mod.rs
@@ -53,3 +53,9 @@ mod loans;
 
 pub use self::session_token::SessionToken;
 mod session_token;
+
+pub use self::library::Library;
+mod library;
+
+pub use self::library_list::LibraryList;
+mod library_list;

--- a/paper/src/scrapers/library_scraper.rs
+++ b/paper/src/scrapers/library_scraper.rs
@@ -41,13 +41,13 @@ impl LibraryScraper {
             .cookie_provider(cookie_store.clone())
             .build()?;
 
-        match self.configuration.api_configuration.api {
+        match self.configuration.api_configuration {
             crate::model::API::HamburgPublic => {
                 self.public_hamburg_fetch_on_current_runtime(&client).await
             }
-            crate::model::API::Opc4v2_13Vzg6 => {
+            crate::model::API::Opc4v2_13Vzg6 { .. } => {
                 client
-                    .get(self.configuration.session_url())
+                    .get(self.configuration.api_configuration.session_url().unwrap())
                     .query(&[("USR", "1022"), ("LAN", "DU"), ("BES", "1")])
                     .send()
                     .await?;

--- a/paper/src/scrapers/opc4v2_13vzg6/opc4v2_13vzg6_account_scraper.rs
+++ b/paper/src/scrapers/opc4v2_13vzg6/opc4v2_13vzg6_account_scraper.rs
@@ -15,7 +15,7 @@ impl Opc4v2_13Vzg6AccountScraper {
 
         let api = APIClient::new_with_network_client(
             client,
-            self.configuration.api_configuration.base_url.clone(),
+            self.configuration.api_configuration.base_url().clone(),
         );
 
         let html = api
@@ -57,10 +57,10 @@ mod tests {
             configuration: crate::configuration::Configuration {
                 username: Some("".to_string()),
                 password: Some("".to_string()),
-                api_configuration: crate::model::APIConfiguration {
-                    api: crate::model::API::Opc4v2_13Vzg6,
+                api_configuration: crate::model::API::Opc4v2_13Vzg6 {
                     base_url: "".to_string(),
                     catalog_url: "".to_string(),
+                    user_query_key: "".to_string(),
                 },
             },
         };
@@ -76,10 +76,10 @@ mod tests {
             configuration: crate::configuration::Configuration {
                 username: Some("".to_string()),
                 password: Some("".to_string()),
-                api_configuration: crate::model::APIConfiguration {
-                    api: crate::model::API::Opc4v2_13Vzg6,
+                api_configuration: crate::model::API::Opc4v2_13Vzg6 {
                     base_url: "".to_string(),
                     catalog_url: "".to_string(),
+                    user_query_key: "".to_string(),
                 },
             },
         };

--- a/paper/src/scrapers/renewal_service.rs
+++ b/paper/src/scrapers/renewal_service.rs
@@ -30,9 +30,9 @@ impl RenewalService {
         renewal_token: Option<String>,
         configuration: Configuration,
     ) -> Result<Loan, PaperError> {
-        match configuration.api_configuration.api {
+        match configuration.api_configuration {
             API::HamburgPublic => self.public_hamburg_renew(item_number, configuration).await,
-            API::Opc4v2_13Vzg6 => {
+            API::Opc4v2_13Vzg6 { .. } => {
                 if let Some(token) = renewal_token {
                     self.opc4v2_13vzg6_renew(token, configuration).await
                 } else {
@@ -65,12 +65,18 @@ impl RenewalService {
         let username = configuration.username.clone().unwrap();
         let password = configuration.password.clone().unwrap();
 
-        client.get(configuration.base_url()).send().await?;
-        client.get(configuration.session_url()).send().await?;
+        client
+            .get(configuration.api_configuration.base_url())
+            .send()
+            .await?;
+        client
+            .get(configuration.api_configuration.session_url().unwrap())
+            .send()
+            .await?;
 
         let url = format!(
             "{}/LBS_WEB/borrower/loans.htm",
-            configuration.api_configuration.base_url
+            configuration.api_configuration.base_url()
         );
 
         let mut headers = HeaderMap::new();

--- a/paper/src/scrapers/search_detail_scraper.rs
+++ b/paper/src/scrapers/search_detail_scraper.rs
@@ -1,23 +1,23 @@
 use crate::api::APIClient;
 use crate::error::PaperError;
-use crate::model::APIConfiguration;
 use crate::model::Availability;
 use crate::model::AvailabilityStatus;
 use crate::model::Loan;
 use crate::model::SearchResultDetail;
+use crate::model::API;
 
 use super::opc4v2_13vzg6::Opc4v2_13Vzg6SearchDetailScraper;
 use super::public_hamburg::HamburgPublicSearchDetailScraper;
 
 #[derive(uniffi::Object)]
 pub(crate) struct SearchDetailScraper {
-    configuration: APIConfiguration,
+    configuration: API,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
 impl SearchDetailScraper {
     #[uniffi::constructor]
-    pub fn new(configuration: APIConfiguration) -> Self {
+    pub fn new(configuration: API) -> Self {
         Self {
             configuration: configuration,
         }
@@ -75,17 +75,15 @@ impl SearchDetailScraper {
         client: &reqwest::Client,
         url: String,
     ) -> Result<SearchResultDetail, PaperError> {
-        let api_client = APIClient::new_with_network_client(
-            client.to_owned(),
-            self.configuration.catalog_url.to_string(),
-        );
+        let api_client =
+            APIClient::new_with_network_client(client.to_owned(), self.configuration.catalog_url());
         let document = api_client.get_html_at_path(url).await?;
 
-        match self.configuration.api {
+        match self.configuration {
             crate::model::API::HamburgPublic => {
                 Ok(HamburgPublicSearchDetailScraper::search_result_detail_from(document).await)
             }
-            crate::model::API::Opc4v2_13Vzg6 => {
+            crate::model::API::Opc4v2_13Vzg6 { .. } => {
                 Opc4v2_13Vzg6SearchDetailScraper {}.search_detail_from(document)
             }
         }

--- a/paper/src/scrapers/search_scraper.rs
+++ b/paper/src/scrapers/search_scraper.rs
@@ -1,19 +1,19 @@
 use crate::api::APIClient;
 use crate::error::PaperError;
-use crate::model::{APIConfiguration, SearchResultList, API};
+use crate::model::{SearchResultList, API};
 use crate::scrapers::opc4v2_13vzg6::Opc4v2_13Vzg6SearchScraper;
 use crate::scrapers::public_hamburg::HamburgPublicSearchScraper;
 use reqwest::Client;
 
 #[derive(uniffi::Object)]
 pub struct SearchScraper {
-    configuration: APIConfiguration,
+    configuration: API,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
 impl SearchScraper {
     #[uniffi::constructor]
-    pub fn new(configuration: APIConfiguration) -> Self {
+    pub fn new(configuration: API) -> Self {
         Self {
             configuration: configuration,
         }
@@ -24,15 +24,15 @@ impl SearchScraper {
         text: &str,
         next_page_url: Option<String>,
     ) -> Result<SearchResultList, PaperError> {
-        match self.configuration.api {
+        match self.configuration {
             API::HamburgPublic => {
                 let search_scraper = HamburgPublicSearchScraper {};
                 search_scraper.search(text, next_page_url).await
             }
-            API::Opc4v2_13Vzg6 => {
+            API::Opc4v2_13Vzg6 { .. } => {
                 let client = Client::new();
                 let api_client =
-                    APIClient::new_with_network_client(client, self.configuration.base_url.clone());
+                    APIClient::new_with_network_client(client, self.configuration.base_url());
 
                 let search_scraper = Opc4v2_13Vzg6SearchScraper {};
                 search_scraper


### PR DESCRIPTION
Summary                                                                                                                                                                                 
                                                                                                                                                                                          
  - Fix OPAC authentication by making the `USR` query parameter configurable per library instead of hardcoded                                                                               
  - Refactor API configuration by moving URL fields directly into the API enum variants, removing the separate APIConfiguration struct                                                    
  - Add Library model with enabled_for_search and enabled_for_login flags for fine-grained control                                                                                        
  - Add LibraryList containing 28 supported German libraries (university and state libraries)                                                                                             
                                                                                                                                                                                          
  🤖 Generated with https://claude.com/claude-code 